### PR TITLE
Are are only allowed 5 keywords per crate.

### DIFF
--- a/cortex-ar/Cargo.toml
+++ b/cortex-ar/Cargo.toml
@@ -14,7 +14,6 @@ keywords = [
     "cortex-a",
     "cortex-r",
     "embedded",
-    "no_std",
     "no-std",
 ]
 license = "MIT OR Apache-2.0"

--- a/cortex-r-rt/Cargo.toml
+++ b/cortex-r-rt/Cargo.toml
@@ -13,7 +13,6 @@ keywords = [
     "arm",
     "cortex-r",
     "embedded",
-    "no_std",
     "no-std",
     "run-time",
 ]


### PR DESCRIPTION
cargo publish said:

```text
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): expected at most 5 keywords per crate
  ```